### PR TITLE
Impact difference in CountryID only if the billing is different than Null

### DIFF
--- a/Gateway/Request/CheckoutSetupDataBuilder.php
+++ b/Gateway/Request/CheckoutSetupDataBuilder.php
@@ -128,7 +128,10 @@ class CheckoutSetupDataBuilder implements BuilderInterface
             $address1->getStreetLine2() != $address2->getStreetLine2() ||
             $address1->getCity() != $address2->getCity() ||
             $address1->getPostcode() != $address2->getPostcode() ||
-            $address1->getCountryId() != $address2->getCountryId()
+            ( 
+                null !== $address1->getCountryId() &&
+                $address1->getCountryId() != $address2->getCountryId()
+            )
         ) {
             return true;
         } else {


### PR DESCRIPTION
If the shipping address is getting default country code before the checkout page is shown then shipping country code is always different than billing country code.